### PR TITLE
Fix XML entity substitution

### DIFF
--- a/case/namespaces.sed
+++ b/case/namespaces.sed
@@ -32,6 +32,7 @@ s_&uco-time;_https://ontology.unifiedcyberontology.org/uco/time/_g
 s_&uco-tool;_https://ontology.unifiedcyberontology.org/uco/tool/_g
 s_&uco-types;_https://ontology.unifiedcyberontology.org/uco/types/_g
 s_&uco-victim;_https://ontology.unifiedcyberontology.org/uco/victim/_g
+s_&vocab;_https://ontology.caseontology.org/case/vocabulary/_g
 s_&vocabulary;_https://ontology.caseontology.org/case/vocabulary/_g
 s_&uco-vocabulary;_https://ontology.unifiedcyberontology.org/uco/vocabulary/_g
 s_&xsd;_http://www.w3.org/2001/XMLSchema#_g

--- a/case/vocabulary.rdf
+++ b/case/vocabulary.rdf
@@ -9,12 +9,12 @@
 	
 	<owl:Ontology rdf:about="https://ontology.caseontology.org/case/vocabulary">
 		<rdfs:label xml:lang="en">vocabularies</rdfs:label>
-		<owl:backwardCompatibleWith rdf:resource="&vocab;1.1.0"/>
-		<owl:priorVersion rdf:resource="&vocab;1.1.0"/>
-		<owl:versionIRI rdf:resource="&vocab;1.2.0"/>
+		<owl:backwardCompatibleWith rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.1.0"/>
+		<owl:priorVersion rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.1.0"/>
+		<owl:versionIRI rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.2.0"/>
 	</owl:Ontology>
 	
-	<rdfs:Datatype rdf:about="&vocab;InvestigationFormVocab">
+	<rdfs:Datatype rdf:about="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">
 		<rdfs:label xml:lang="en-US">Investigation Form Vocabulary</rdfs:label>
 		<rdfs:comment xml:lang="en-US">Defines an open-vocabulary of investigation forms.</rdfs:comment>
 		<owl:equivalentClass>
@@ -22,13 +22,13 @@
 				<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 				<owl:oneOf>
 					<rdf:Description>
-						<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">case</rdf:first>
+						<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">case</rdf:first>
 						<rdf:rest>
 							<rdf:Description>
-								<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">incident</rdf:first>
+								<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">incident</rdf:first>
 								<rdf:rest>
 									<rdf:Description>
-										<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">suspicious-activity</rdf:first>
+										<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">suspicious-activity</rdf:first>
 										<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
 									</rdf:Description>
 								</rdf:rest>

--- a/case/vocabulary/0.7.1.rdf
+++ b/case/vocabulary/0.7.1.rdf
@@ -9,13 +9,13 @@
 	
 	<owl:Ontology rdf:about="https://ontology.caseontology.org/case/vocabulary">
 		<rdfs:label xml:lang="en">vocabularies</rdfs:label>
-		<owl:incompatibleWith rdf:resource="&vocab;0.7.1"/>
+		<owl:incompatibleWith rdf:resource="https://ontology.caseontology.org/case/vocabulary/0.7.1"/>
 		<owl:ontologyIRI rdf:resource="https://ontology.caseontology.org/case/vocabulary"/>
-		<owl:priorVersion rdf:resource="&vocab;0.7.1"/>
-		<owl:versionIRI rdf:resource="&vocab;1.0.0"/>
+		<owl:priorVersion rdf:resource="https://ontology.caseontology.org/case/vocabulary/0.7.1"/>
+		<owl:versionIRI rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.0.0"/>
 	</owl:Ontology>
 	
-	<rdfs:Datatype rdf:about="&vocab;InvestigationFormVocab">
+	<rdfs:Datatype rdf:about="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">
 		<rdfs:label xml:lang="en-US">Investigation Form Vocabulary</rdfs:label>
 		<rdfs:comment xml:lang="en-US">Defines an open-vocabulary of investigation forms.</rdfs:comment>
 		<owl:equivalentClass>
@@ -23,13 +23,13 @@
 				<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 				<owl:oneOf>
 					<rdf:Description>
-						<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">case</rdf:first>
+						<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">case</rdf:first>
 						<rdf:rest>
 							<rdf:Description>
-								<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">incident</rdf:first>
+								<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">incident</rdf:first>
 								<rdf:rest>
 									<rdf:Description>
-										<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">suspicious-activity</rdf:first>
+										<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">suspicious-activity</rdf:first>
 										<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
 									</rdf:Description>
 								</rdf:rest>

--- a/case/vocabulary/1.0.0.rdf
+++ b/case/vocabulary/1.0.0.rdf
@@ -9,13 +9,13 @@
 	
 	<owl:Ontology rdf:about="https://ontology.caseontology.org/case/vocabulary">
 		<rdfs:label xml:lang="en">vocabularies</rdfs:label>
-		<owl:incompatibleWith rdf:resource="&vocab;0.7.1"/>
+		<owl:incompatibleWith rdf:resource="https://ontology.caseontology.org/case/vocabulary/0.7.1"/>
 		<owl:ontologyIRI rdf:resource="https://ontology.caseontology.org/case/vocabulary"/>
-		<owl:priorVersion rdf:resource="&vocab;0.7.1"/>
-		<owl:versionIRI rdf:resource="&vocab;1.0.0"/>
+		<owl:priorVersion rdf:resource="https://ontology.caseontology.org/case/vocabulary/0.7.1"/>
+		<owl:versionIRI rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.0.0"/>
 	</owl:Ontology>
 	
-	<rdfs:Datatype rdf:about="&vocab;InvestigationFormVocab">
+	<rdfs:Datatype rdf:about="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">
 		<rdfs:label xml:lang="en-US">Investigation Form Vocabulary</rdfs:label>
 		<rdfs:comment xml:lang="en-US">Defines an open-vocabulary of investigation forms.</rdfs:comment>
 		<owl:equivalentClass>
@@ -23,13 +23,13 @@
 				<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 				<owl:oneOf>
 					<rdf:Description>
-						<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">case</rdf:first>
+						<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">case</rdf:first>
 						<rdf:rest>
 							<rdf:Description>
-								<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">incident</rdf:first>
+								<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">incident</rdf:first>
 								<rdf:rest>
 									<rdf:Description>
-										<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">suspicious-activity</rdf:first>
+										<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">suspicious-activity</rdf:first>
 										<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
 									</rdf:Description>
 								</rdf:rest>

--- a/case/vocabulary/1.2.0.rdf
+++ b/case/vocabulary/1.2.0.rdf
@@ -9,12 +9,12 @@
 	
 	<owl:Ontology rdf:about="https://ontology.caseontology.org/case/vocabulary">
 		<rdfs:label xml:lang="en">vocabularies</rdfs:label>
-		<owl:backwardCompatibleWith rdf:resource="&vocab;1.1.0"/>
-		<owl:priorVersion rdf:resource="&vocab;1.1.0"/>
-		<owl:versionIRI rdf:resource="&vocab;1.2.0"/>
+		<owl:backwardCompatibleWith rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.1.0"/>
+		<owl:priorVersion rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.1.0"/>
+		<owl:versionIRI rdf:resource="https://ontology.caseontology.org/case/vocabulary/1.2.0"/>
 	</owl:Ontology>
 	
-	<rdfs:Datatype rdf:about="&vocab;InvestigationFormVocab">
+	<rdfs:Datatype rdf:about="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">
 		<rdfs:label xml:lang="en-US">Investigation Form Vocabulary</rdfs:label>
 		<rdfs:comment xml:lang="en-US">Defines an open-vocabulary of investigation forms.</rdfs:comment>
 		<owl:equivalentClass>
@@ -22,13 +22,13 @@
 				<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 				<owl:oneOf>
 					<rdf:Description>
-						<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">case</rdf:first>
+						<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">case</rdf:first>
 						<rdf:rest>
 							<rdf:Description>
-								<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">incident</rdf:first>
+								<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">incident</rdf:first>
 								<rdf:rest>
 									<rdf:Description>
-										<rdf:first rdf:datatype="&vocab;InvestigationFormVocab">suspicious-activity</rdf:first>
+										<rdf:first rdf:datatype="https://ontology.caseontology.org/case/vocabulary/InvestigationFormVocab">suspicious-activity</rdf:first>
 										<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
 									</rdf:Description>
 								</rdf:rest>


### PR DESCRIPTION
The CASE vocabulary.ttl file uses the prefix "vocab", contrary to other patterns throughout CASE and UCO.  This would typically not be a problem, except the process used in the documentation site to convert Turtle to RDF currently has a defect in handling XML entities, and the workaround didn't catch this atypical namespace prefix.